### PR TITLE
yarn build to compile binaries (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 node_modules
 yarn.lock
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     "commander": "^2.19.0",
     "json2csv": "^4.2.1"
   },
+  "devDependencies": {
+    "pkg": "^4.3.4"
+  },
+  "scripts": {
+    "build": "pkg . --out-path ./build"
+  },
   "bin": {
     "rotten-reviews": "./bin/rotten-reviews.js"
   },


### PR DESCRIPTION
I haven't got any ideas on how to automate compiling binaries, so far just adding `pkg` to the dev dependency and by running `yarn build` it will compile the binaries to `./build` directory.