### PR TITLE
remove csv module from project (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,9 @@ Scrapes audience movie or tv show reviews from rotten tomatoes
 
 Examples:
   rotten-reviews venom_2018 100
-  rotten-reviews venom_2018 100 --csv
   rotten-reviews doctor_who/s11 10 --tv   (include the season # for tv shows)
 
 Options:
-  --csv       exports to csv (defaults to json)
   --tv        search as a tv show (defaults to movie)
   -h, --help  output usage information
 ```
@@ -117,7 +115,6 @@ You can view more examples by opening the [examples folder](/examples).
 - [`axios`](https://github.com/axios/axios) for fetching webpages
 - [`cheerio`](https://github.com/cheeriojs/cheerio) for scraping the webpage contents
 - [`commander.js`](https://github.com/tj/commander.js) for running this package as a CLI app
-- [`json2csv`](https://github.com/zemirco/json2csv) for converting scraped reviews to CSV on the CLI app
 - [`pkg`](https://github.com/zeit/pkg) for compiling to binaries
 
 ## License

--- a/bin/rotten-reviews.js
+++ b/bin/rotten-reviews.js
@@ -1,30 +1,21 @@
 #!/usr/bin/env node
 
 const Commander = require('commander')
-const Json2CsvParser = require('json2csv').Parser
 const RottenReviews = require('..')
-
-const Csv = new Json2CsvParser({
-  fields: ['reviewer', 'date', 'stars', 'review'],
-})
 
 const description = `Scrapes audience movie or tv show reviews from rotten tomatoes
 
 Examples:
   rotten-reviews venom_2018 100
-  rotten-reviews venom_2018 100 --csv
   rotten-reviews doctor_who/s11 10 --tv   (include the season # for tv shows)`
 
 Commander.description(description)
-  .option('--csv', 'exports to csv (defaults to json)')
   .option('--tv', 'search as a tv show (defaults to movie)')
   .arguments('<title> <count>')
   .action((title, count) => {
     RottenReviews.getAudienceReviews(title, count, Commander.tv)
       .then(reviews => {
-        console.log(
-          Commander.csv ? Csv.parse(reviews) : JSON.stringify(reviews, null, 2)
-        )
+        console.log(JSON.stringify(reviews, null, 2))
       })
       .catch(error => {
         console.error(error.message)

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "cheerio": "^1.0.0-rc.2",
-    "commander": "^2.19.0",
-    "json2csv": "^4.2.1"
+    "commander": "^2.19.0"
   },
   "bin": {
     "rotten-reviews": "./bin/rotten-reviews.js"


### PR DESCRIPTION
You can pipe the `json2csv` package installed globally to achieve the same thing. ie `./bin/rotten-reviews.js venom_2018 10 | json2csv`